### PR TITLE
Attempt a fix for error introduced in most recent update.

### DIFF
--- a/js/find-the-culprit.js
+++ b/js/find-the-culprit.js
@@ -227,7 +227,7 @@ function doBinarySearchStep() {
 }
 
 async function deactivationStep(chosenModules = []) {
-  if (chosenModules.length <= 1) return renderFinalDialog(chosenModules[0]);
+  if (chosenModules.length === 1) return renderFinalDialog(chosenModules[0]);
 
   const currSettings = game.settings.get(moduleName, "modules");
 


### PR DESCRIPTION
The most recent update introduced a logic error - deactivationStep is used within the first step to initially deactivate all modules, and is passed the value of `[]` for chosenModules. This causes an erroneous short-circuit to renderFinalDialog with a non-existent array entry.