### PR TITLE
Restore compatibility with versions prior to v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.3
+
+- Restore compatibility with versions prior to V10
+
 # v1.4.1
 
 - Now compatible with FVTT v10, thanks to @arcanist

--- a/js/find-the-culprit.js
+++ b/js/find-the-culprit.js
@@ -16,10 +16,12 @@ function registerSetting() {
 }
 
 // Temporarily required by foundryvtt/foundryvtt#7740
-Hooks.on("setup", () => {
-	game.settings.settings.get(`core.${ModuleManagement.CONFIG_SETTING}`).onChange =
-		foundry.utils.debouncedReload ?? window.location.reload;
-});
+if (game.release?.generation >= 10) {
+	Hooks.on("setup", () => {
+		game.settings.settings.get(`core.${ModuleManagement.CONFIG_SETTING}`).onChange =
+			foundry.utils.debouncedReload ?? window.location.reload;
+	});
+}
 
 Hooks.on("renderModuleManagement", onRenderModuleManagement);
 

--- a/module.json
+++ b/module.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/Moerill/fvtt-find-the-culprit/issues",
   "changelog": "https://github.com/Moerill/fvtt-find-the-culprit/blob/master/CHANGELOG.md",
   "flags": {},
-  "version": "1.4.2",
+  "version": "1.4.3",
   "compatibility": {
     "minimum": "9",
     "verified": "10"
@@ -32,6 +32,6 @@
   "dependencies": [],
   "socket": false,
   "manifest": "https://raw.githubusercontent.com/Moerill/fvtt-find-the-culprit/master/module.json",
-  "download": "https://github.com/Moerill/fvtt-find-the-culprit/releases/download/v1.4.2/v1.4.2.zip",
+  "download": "https://github.com/Moerill/fvtt-find-the-culprit/releases/download/v1.4.3/v1.4.3.zip",
   "protected": false
 }


### PR DESCRIPTION
My previous PR used a function that is not available on V9, so this PR should fix the issue users are having in #29 