### PR TITLE
onchange patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v1.4.5
-- Moved window reload logic to `then` instead of core settings `onchange` event. Fixes incompatibility between MM+ and Ftc
+- Moved window reload logic to `await` instead of core settings `onchange` event. Fixes incompatibility between MM+ and Ftc
 
 # v1.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.4.5
+- Moved window reload logic to `then` instead of core settings `onchange` event. Fixes incompatibility between MM+ and Ftc
+
 # v1.4.4
 
 - Now compatible with FVTT v10, thanks to @arcanist

--- a/js/find-the-culprit.js
+++ b/js/find-the-culprit.js
@@ -16,12 +16,12 @@ function registerSetting() {
 }
 
 // Temporarily required by foundryvtt/foundryvtt#7740
-Hooks.on("setup", () => {
+/*Hooks.on("setup", () => {
     if (game.release?.generation >= 10) {
 		game.settings.settings.get(`core.${ModuleManagement.CONFIG_SETTING}`).onChange =
 			foundry.utils.debouncedReload ?? window.location.reload;
       }
-});
+});*/
 
 Hooks.on("renderModuleManagement", onRenderModuleManagement);
 
@@ -354,7 +354,9 @@ async function deactivationStep(chosenModules = []) {
     await game.settings.set(moduleName, "modules", currSettings);
   }
 
-  game.settings.set("core", ModuleManagement.CONFIG_SETTING, original);
+  game.settings.set("core", ModuleManagement.CONFIG_SETTING, original).then(r => {
+    return foundry.utils.debouncedReload() ?? window.location.reload
+  });;
 }
 
 async function reactivateModules() {
@@ -364,7 +366,9 @@ async function reactivateModules() {
   );
   for (let mod in curr.original) original[mod] = curr.original[mod];
 
-  game.settings.set("core", ModuleManagement.CONFIG_SETTING, original);
+  game.settings.set("core", ModuleManagement.CONFIG_SETTING, original).then(r => {
+    return foundry.utils.debouncedReload() ?? window.location.reload
+  });;
 }
 
 async function resetSettings() {

--- a/js/find-the-culprit.js
+++ b/js/find-the-culprit.js
@@ -15,14 +15,6 @@ function registerSetting() {
   });
 }
 
-// Temporarily required by foundryvtt/foundryvtt#7740
-/*Hooks.on("setup", () => {
-    if (game.release?.generation >= 10) {
-		game.settings.settings.get(`core.${ModuleManagement.CONFIG_SETTING}`).onChange =
-			foundry.utils.debouncedReload ?? window.location.reload;
-      }
-});*/
-
 Hooks.on("renderModuleManagement", onRenderModuleManagement);
 
 function onRenderModuleManagement(app, html, options) {
@@ -354,9 +346,8 @@ async function deactivationStep(chosenModules = []) {
     await game.settings.set(moduleName, "modules", currSettings);
   }
 
-  game.settings.set("core", ModuleManagement.CONFIG_SETTING, original).then(r => {
-    return foundry.utils.debouncedReload() ?? window.location.reload
-  });;
+  await game.settings.set("core", ModuleManagement.CONFIG_SETTING, original)
+  (foundry.utils.debouncedReload ?? window.location.reload)(); // Temporarily required by foundryvtt/foundryvtt#7740
 }
 
 async function reactivateModules() {
@@ -366,9 +357,8 @@ async function reactivateModules() {
   );
   for (let mod in curr.original) original[mod] = curr.original[mod];
 
-  game.settings.set("core", ModuleManagement.CONFIG_SETTING, original).then(r => {
-    return foundry.utils.debouncedReload() ?? window.location.reload
-  });;
+  await game.settings.set("core", ModuleManagement.CONFIG_SETTING, original)
+  (foundry.utils.debouncedReload ?? window.location.reload)(); // Temporarily required by foundryvtt/foundryvtt#7740
 }
 
 async function resetSettings() {

--- a/module.json
+++ b/module.json
@@ -32,6 +32,6 @@
   "dependencies": [],
   "socket": false,
   "manifest": "https://raw.githubusercontent.com/Moerill/fvtt-find-the-culprit/master/module.json",
-  "download": "https://github.com/Moerill/fvtt-find-the-culprit/releases/download/v1.4.4/v1.4.4.zip",
+  "download": "https://github.com/Moerill/fvtt-find-the-culprit/releases/download/v1.4.5/v1.4.5.zip",
   "protected": false
 }

--- a/module.json
+++ b/module.json
@@ -15,7 +15,7 @@
   "bugs": "https://github.com/Moerill/fvtt-find-the-culprit/issues",
   "changelog": "https://github.com/Moerill/fvtt-find-the-culprit/blob/master/CHANGELOG.md",
   "flags": {},
-  "version": "1.4.4",
+  "version": "1.4.5",
   "compatibility": {
     "minimum": "9",
     "verified": "10"


### PR DESCRIPTION
Removed attaching an onchange event to core setting. Instead places it in `then` promise.

This patch is designed to fix the conflict between MM+ and FtC, However, reloading after the setting is saved will remove any conflict with any other Module attaching an `onchange` event to that setting.